### PR TITLE
Added hint for EditText in notes fragment for entering folder name

### DIFF
--- a/app/src/main/java/com/studypartner/fragments/NotesFragment.java
+++ b/app/src/main/java/com/studypartner/fragments/NotesFragment.java
@@ -821,20 +821,6 @@ public class NotesFragment extends Fragment implements NotesAdapter.NotesClickLi
 	private void addFolder() {
 		if (isExternalStorageReadableWritable()) {
 			if (writeReadPermission()) {
-				
-				File file;
-				
-				int count = 0;
-				do {
-					String newFolder = "New Folder";
-					if (count > 0) {
-						newFolder += " " + count;
-					}
-					++count;
-					file = new File(noteFolder, newFolder);
-				} while (file.exists());
-				
-				
 				AlertDialog.Builder alertDialog = new AlertDialog.Builder(getContext());
 				alertDialog.setMessage("Name of the folder");
 				final EditText input = new EditText(getContext());
@@ -842,7 +828,7 @@ public class NotesFragment extends Fragment implements NotesAdapter.NotesClickLi
 						LinearLayout.LayoutParams.MATCH_PARENT,
 						LinearLayout.LayoutParams.MATCH_PARENT);
 				input.setLayoutParams(lp);
-				input.setText(file.getName());
+				input.setHint("Enter folder name");//added hint for editText in notes fragment for entering folder name instead of text
 				alertDialog.setView(input);
 				
 				alertDialog.setPositiveButton("OK", new DialogInterface.OnClickListener() {


### PR DESCRIPTION
Added hint for EditText in notes fragment for entering folder name while creating a new folder instead of text (issue#55).

Fixes #55

## Are you a part of GSSOC' 21?
- [x] Yes
- [ ] No

## Changes made
Added hint for EditText in notes fragment for entering folder name while creating a new folder instead of text.


## Type of change

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Checklist:
<!--
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots

 Original           | Updated
 :--------------------: |:--------------------:
 **![Screenshot_1615914380](https://user-images.githubusercontent.com/54719657/111352087-d79e4180-86a9-11eb-885f-dc699701eb53.png)**  | <b>![Screenshot_1615914138](https://user-images.githubusercontent.com/54719657/111351902-a58cdf80-86a9-11eb-8a54-8e399c93e66d.png)</b> |
