### PR TITLE
Added UNDO option after delete action

### DIFF
--- a/app/src/main/java/com/studypartner/fragments/NotesFragment.java
+++ b/app/src/main/java/com/studypartner/fragments/NotesFragment.java
@@ -1074,75 +1074,72 @@ public class NotesFragment extends Fragment implements NotesAdapter.NotesClickLi
 
 							if (mInterstitialAd.isLoaded()) {
 								mInterstitialAd.show();
-
-								if (mInterstitialAd.isLoaded()) {
-									mInterstitialAd.show();
-								}
-								for (int i = selectedItemPositions.size() - 1; i >= 0; i--) {
-									File file = new File(notes.get(selectedItemPositions.get(i)).getPath());
-									deleteRecursive(file);
-
-									if (notes.get(selectedItemPositions.get(i)).getType() == FileType.FILE_TYPE_FOLDER) {
-										ArrayList<FileItem> linksToBeRemoved = new ArrayList<>();
-										for (FileItem linkItem : links) {
-											if (linkItem.getPath().contains(file.getPath())) {
-												linksToBeRemoved.add(linkItem);
-											}
-										}
-										links.removeAll(linksToBeRemoved);
-
-										SharedPreferences linkPreference = requireActivity().getSharedPreferences(FirebaseAuth.getInstance().getCurrentUser().getUid() + "LINK", MODE_PRIVATE);
-										SharedPreferences.Editor linkPreferenceEditor = linkPreference.edit();
-
-										if (links.size() == 0) {
-											linkPreferenceEditor.putBoolean("LINK_ITEMS_EXISTS", false);
-										}
-										Gson gson = new Gson();
-										linkPreferenceEditor.putString("LINK_ITEMS", gson.toJson(links));
-										linkPreferenceEditor.apply();
-
-										ArrayList<FileItem> starredToBeRemoved = new ArrayList<>();
-										for (FileItem starItem : starred) {
-											if (starItem.getPath().contains(file.getPath()) && !starItem.getPath().equals(file.getPath())) {
-												starredToBeRemoved.add(starItem);
-											}
-										}
-										starred.removeAll(starredToBeRemoved);
-
-										SharedPreferences starredPreference = requireActivity().getSharedPreferences(FirebaseAuth.getInstance().getCurrentUser().getUid() + "STARRED", MODE_PRIVATE);
-										SharedPreferences.Editor starredPreferenceEditor = starredPreference.edit();
-
-										if (starred.size() == 0) {
-											starredPreferenceEditor.putBoolean("STARRED_ITEMS_EXISTS", false);
-										}
-										starredPreferenceEditor.putString("STARRED_ITEMS", gson.toJson(starred));
-										starredPreferenceEditor.apply();
-									}
-
-									int starPosition = starredIndex(selectedItemPositions.get(i));
-									if (starPosition != -1) {
-										starred.remove(starPosition);
-										SharedPreferences starredPreference = requireActivity().getSharedPreferences(FirebaseAuth.getInstance().getCurrentUser().getUid() + "STARRED", MODE_PRIVATE);
-										SharedPreferences.Editor starredPreferenceEditor = starredPreference.edit();
-
-										if (starred.size() == 0) {
-											starredPreferenceEditor.putBoolean("STARRED_ITEMS_EXISTS", false);
-										}
-										Gson gson = new Gson();
-										starredPreferenceEditor.putString("STARRED_ITEMS", gson.toJson(starred));
-										starredPreferenceEditor.apply();
-									}
-
-									mNotesAdapter.notifyItemRemoved(selectedItemPositions.get(i));
-									notes.remove(selectedItemPositions.get(i).intValue());
-								}
-
-								if (notes.isEmpty()) {
-									mEmptyLayout.setVisibility(View.VISIBLE);
-								}
-
-								activity.mBottomAppBar.performShow();
 							}
+
+							for (int i = selectedItemPositions.size() - 1; i >= 0; i--) {
+								File file = new File(notes.get(selectedItemPositions.get(i)).getPath());
+								deleteRecursive(file);
+
+								if (notes.get(selectedItemPositions.get(i)).getType() == FileType.FILE_TYPE_FOLDER) {
+									ArrayList<FileItem> linksToBeRemoved = new ArrayList<>();
+									for (FileItem linkItem : links) {
+										if (linkItem.getPath().contains(file.getPath())) {
+											linksToBeRemoved.add(linkItem);
+										}
+									}
+									links.removeAll(linksToBeRemoved);
+
+									SharedPreferences linkPreference = requireActivity().getSharedPreferences(FirebaseAuth.getInstance().getCurrentUser().getUid() + "LINK", MODE_PRIVATE);
+									SharedPreferences.Editor linkPreferenceEditor = linkPreference.edit();
+
+									if (links.size() == 0) {
+										linkPreferenceEditor.putBoolean("LINK_ITEMS_EXISTS", false);
+									}
+									Gson gson = new Gson();
+									linkPreferenceEditor.putString("LINK_ITEMS", gson.toJson(links));
+									linkPreferenceEditor.apply();
+
+									ArrayList<FileItem> starredToBeRemoved = new ArrayList<>();
+									for (FileItem starItem : starred) {
+										if (starItem.getPath().contains(file.getPath()) && !starItem.getPath().equals(file.getPath())) {
+											starredToBeRemoved.add(starItem);
+										}
+									}
+									starred.removeAll(starredToBeRemoved);
+
+									SharedPreferences starredPreference = requireActivity().getSharedPreferences(FirebaseAuth.getInstance().getCurrentUser().getUid() + "STARRED", MODE_PRIVATE);
+									SharedPreferences.Editor starredPreferenceEditor = starredPreference.edit();
+
+									if (starred.size() == 0) {
+										starredPreferenceEditor.putBoolean("STARRED_ITEMS_EXISTS", false);
+									}
+									starredPreferenceEditor.putString("STARRED_ITEMS", gson.toJson(starred));
+									starredPreferenceEditor.apply();
+								}
+
+								int starPosition = starredIndex(selectedItemPositions.get(i));
+								if (starPosition != -1) {
+									starred.remove(starPosition);
+									SharedPreferences starredPreference = requireActivity().getSharedPreferences(FirebaseAuth.getInstance().getCurrentUser().getUid() + "STARRED", MODE_PRIVATE);
+									SharedPreferences.Editor starredPreferenceEditor = starredPreference.edit();
+
+									if (starred.size() == 0) {
+										starredPreferenceEditor.putBoolean("STARRED_ITEMS_EXISTS", false);
+									}
+									Gson gson = new Gson();
+									starredPreferenceEditor.putString("STARRED_ITEMS", gson.toJson(starred));
+									starredPreferenceEditor.apply();
+								}
+
+								mNotesAdapter.notifyItemRemoved(selectedItemPositions.get(i));
+								notes.remove(selectedItemPositions.get(i).intValue());
+							}
+
+							if (notes.isEmpty()) {
+								mEmptyLayout.setVisibility(View.VISIBLE);
+							}
+
+							activity.mBottomAppBar.performShow();
 						}
 					}
 				});

--- a/app/src/main/java/com/studypartner/fragments/StarredFragment.java
+++ b/app/src/main/java/com/studypartner/fragments/StarredFragment.java
@@ -24,6 +24,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
+import com.google.android.material.snackbar.Snackbar;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -565,69 +566,99 @@ public class StarredFragment extends Fragment implements NotesAdapter.NotesClick
                         builder.setTitle("Delete File");
                         builder.setMessage("Are you sure you want to delete the file?");
                         builder.setPositiveButton("Yes", new DialogInterface.OnClickListener() {
-                            @Override
-                            public void onClick(DialogInterface dialog, int which) {
-                                if (starred.get(position).getType() != FileType.FILE_TYPE_LINK) {
-                                    File file = new File(starred.get(position).getPath());
-                                    deleteRecursive(file);
+							@Override
+							public void onClick(DialogInterface dialog, int which) {
 
-                                    if (starred.get(position).getType() == FileType.FILE_TYPE_FOLDER) {
-                                        ArrayList<FileItem> linksToBeRemoved = new ArrayList<>();
-                                        for (FileItem linkItem : links) {
-                                            if (linkItem.getPath().contains(file.getPath())) {
-                                                linksToBeRemoved.add(linkItem);
-                                            }
-                                        }
-                                        links.removeAll(linksToBeRemoved);
+								// Hiding the file to be deleted from RecyclerView
+								recyclerView.findViewHolderForAdapterPosition(position).itemView.
+										findViewById(R.id.noteItemLayout).setVisibility(View.GONE);
 
-                                        SharedPreferences linkPreference = requireActivity().getSharedPreferences(FirebaseAuth.getInstance().getCurrentUser().getUid() + "LINK", MODE_PRIVATE);
-                                        SharedPreferences.Editor linkPreferenceEditor = linkPreference.edit();
+								// Displaying a Snackbar to allow user to UNDO the delete file action
+								Snackbar undoSnackbar = Snackbar.make(recyclerView, R.string.starred_file_deleted, Snackbar.LENGTH_LONG);
+								undoSnackbar.setAction(R.string.notes_action_undo, new View.OnClickListener() {
+									@Override
+									public void onClick(View view) {
+										// Making folder visible to user again
+										recyclerView.findViewHolderForAdapterPosition(position).itemView.
+												findViewById(R.id.noteItemLayout).setVisibility(View.VISIBLE);
+									}
 
-                                        if (links.size() == 0) {
-                                            linkPreferenceEditor.putBoolean("LINK_ITEMS_EXISTS", false);
-                                        }
-                                        Gson gson = new Gson();
-                                        linkPreferenceEditor.putString("LINK_ITEMS", gson.toJson(links));
-                                        linkPreferenceEditor.apply();
+								}).setDuration(3000).setActionTextColor(getResources().getColor(R.color.colorPrimary));
 
-                                        ArrayList<FileItem> starredToBeRemoved = new ArrayList<>();
-                                        for (FileItem starItem : starred) {
-                                            if (starItem.getPath().contains(file.getPath()) && !starItem.getPath().equals(file.getPath())) {
-                                                starredToBeRemoved.add(starItem);
-                                            }
-                                        }
-                                        starredToBeRemoved.add(starred.get(position));
-                                        starred.removeAll(starredToBeRemoved);
+								undoSnackbar.addCallback(new Snackbar.Callback() {
+									// Called when the Snackbar is dismissed by an event other than
+									// clicking of UNDO.
+									@Override
+									public void onDismissed(Snackbar snackbar, int event) {
+										if (event == Snackbar.Callback.DISMISS_EVENT_TIMEOUT ||
+												event == Snackbar.Callback.DISMISS_EVENT_SWIPE ||
+												event == Snackbar.Callback.DISMISS_EVENT_MANUAL) {
 
-                                        SharedPreferences starredPreference = requireActivity().getSharedPreferences(FirebaseAuth.getInstance().getCurrentUser().getUid() + "STARRED", MODE_PRIVATE);
-                                        SharedPreferences.Editor starredPreferenceEditor = starredPreference.edit();
+											if (starred.get(position).getType() != FileType.FILE_TYPE_LINK) {
+												File file = new File(starred.get(position).getPath());
+												deleteRecursive(file);
 
-                                        if (starred.size() == 0) {
-                                            starredPreferenceEditor.putBoolean("STARRED_ITEMS_EXISTS", false);
-                                            mEmptyLayout.setVisibility(View.VISIBLE);
-                                        }
-                                        starredPreferenceEditor.putString("STARRED_ITEMS", gson.toJson(starred));
-                                        starredPreferenceEditor.apply();
-                                    }
+												if (starred.get(position).getType() == FileType.FILE_TYPE_FOLDER) {
+													ArrayList<FileItem> linksToBeRemoved = new ArrayList<>();
+													for (FileItem linkItem : links) {
+														if (linkItem.getPath().contains(file.getPath())) {
+															linksToBeRemoved.add(linkItem);
+														}
+													}
+													links.removeAll(linksToBeRemoved);
 
-                                } else {
-                                    int linkPosition = linkIndex(position);
-                                    if (linkPosition != -1) {
-                                        links.remove(linkPosition);
-                                        SharedPreferences linkPreference = requireActivity().getSharedPreferences(FirebaseAuth.getInstance().getCurrentUser().getUid() + "LINK", MODE_PRIVATE);
-                                        SharedPreferences.Editor linkPreferenceEditor = linkPreference.edit();
+													SharedPreferences linkPreference = requireActivity().getSharedPreferences(FirebaseAuth.getInstance().getCurrentUser().getUid() + "LINK", MODE_PRIVATE);
+													SharedPreferences.Editor linkPreferenceEditor = linkPreference.edit();
 
-                                        if (links.size() == 0) {
-                                            linkPreferenceEditor.putBoolean("LINK_ITEMS_EXISTS", false);
-                                        }
-                                        Gson gson = new Gson();
-                                        linkPreferenceEditor.putString("LINK_ITEMS", gson.toJson(links));
-                                        linkPreferenceEditor.apply();
-                                    }
-                                }
-                                mStarredAdapter.notifyDataSetChanged();
-                            }
-                        });
+													if (links.size() == 0) {
+														linkPreferenceEditor.putBoolean("LINK_ITEMS_EXISTS", false);
+													}
+													Gson gson = new Gson();
+													linkPreferenceEditor.putString("LINK_ITEMS", gson.toJson(links));
+													linkPreferenceEditor.apply();
+
+													ArrayList<FileItem> starredToBeRemoved = new ArrayList<>();
+													for (FileItem starItem : starred) {
+														if (starItem.getPath().contains(file.getPath()) && !starItem.getPath().equals(file.getPath())) {
+															starredToBeRemoved.add(starItem);
+														}
+													}
+													starredToBeRemoved.add(starred.get(position));
+													starred.removeAll(starredToBeRemoved);
+
+													SharedPreferences starredPreference = requireActivity().getSharedPreferences(FirebaseAuth.getInstance().getCurrentUser().getUid() + "STARRED", MODE_PRIVATE);
+													SharedPreferences.Editor starredPreferenceEditor = starredPreference.edit();
+
+													if (starred.size() == 0) {
+														starredPreferenceEditor.putBoolean("STARRED_ITEMS_EXISTS", false);
+														mEmptyLayout.setVisibility(View.VISIBLE);
+													}
+													starredPreferenceEditor.putString("STARRED_ITEMS", gson.toJson(starred));
+													starredPreferenceEditor.apply();
+												}
+
+											} else {
+												int linkPosition = linkIndex(position);
+												if (linkPosition != -1) {
+													links.remove(linkPosition);
+													SharedPreferences linkPreference = requireActivity().getSharedPreferences(FirebaseAuth.getInstance().getCurrentUser().getUid() + "LINK", MODE_PRIVATE);
+													SharedPreferences.Editor linkPreferenceEditor = linkPreference.edit();
+
+													if (links.size() == 0) {
+														linkPreferenceEditor.putBoolean("LINK_ITEMS_EXISTS", false);
+													}
+													Gson gson = new Gson();
+													linkPreferenceEditor.putString("LINK_ITEMS", gson.toJson(links));
+													linkPreferenceEditor.apply();
+												}
+											}
+											mStarredAdapter.notifyDataSetChanged();
+										}
+									}
+								});
+								undoSnackbar.show(); // Snackbar will appear for 3 seconds
+							}
+						});
                         builder.setNegativeButton("No", new DialogInterface.OnClickListener() {
                             @Override
                             public void onClick(DialogInterface dialog, int which) {

--- a/app/src/main/java/com/studypartner/models/FileItem.java
+++ b/app/src/main/java/com/studypartner/models/FileItem.java
@@ -87,6 +87,14 @@ public class FileItem implements Parcelable {
 			this.dateCreated = String.valueOf(file.lastModified());
 		}
 	}
+
+	public String getCreationTime() {
+		return dateCreated;
+	}
+
+	public void setCreationTime(String str) {
+		this.dateCreated = str;
+	}
 	
 	public String getPath() {
 		return path;

--- a/app/src/main/res/layout/notes_item.xml
+++ b/app/src/main/res/layout/notes_item.xml
@@ -13,6 +13,7 @@
     app:cardCornerRadius="@dimen/smallMargin">
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/noteItemLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:padding="@dimen/smallPadding">

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,7 +99,9 @@
     <string name="file_sort_order_cd">Sort Order</string>
     <string name="file_empty_icon_cd">File Empty Icon</string>
     <string name="file_empty">No items</string>
+    <string name="file_action_deleted">File deleted</string>
     <string name="starred_file_deleted">Starred file deleted</string>
+    <string name="multiple_files_deleted">Selected files deleted</string>
 
     <string name="notes_action_delete">Delete</string>
     <string name="notes_action_unstar">Unstar</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,6 +99,7 @@
     <string name="file_sort_order_cd">Sort Order</string>
     <string name="file_empty_icon_cd">File Empty Icon</string>
     <string name="file_empty">No items</string>
+    <string name="starred_file_deleted">Starred file deleted</string>
 
     <string name="notes_action_delete">Delete</string>
     <string name="notes_action_unstar">Unstar</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -104,6 +104,9 @@
     <string name="notes_action_unstar">Unstar</string>
     <string name="notes_action_select_all">Select All</string>
     <string name="notes_action_share">Share</string>
+    <string name="notes_action_undo">UNDO</string>
+    <string name="notes_action_deleted">Folder deleted</string>
+    <string name="multiple_folders_deleted">Selected folders deleted</string>
 
     <string name="notes_empty_icon_cd">Notes Empty Icon</string>
     <string name="notes_empty">No subjects stored</string>


### PR DESCRIPTION
Whenever folder(s) are deleted in Notes/Starred section of app, an UNDO Snackbar appears

Fixes #27  🔐

## Are you a part of GSSOC' 21 ❓
- [x] Yes ✔️
- [ ] No ✖️
## Describe the changes you've made 🏆
Deletion of folder(s) in the Notes and Starred section of the app is a major task, and users should get an option to reconsider their delete action. So, when folder(s) are deleted in Notes/Starred section of app, **an UNDO Snackbar** appears for 3 seconds. If user clicks on UNDO, deleted folder(s)/files(s) get restored.  

## Type of change 🖇️

Please delete options that are not relevant.
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] New feature (non-breaking change which adds functionality)


## Checklist: 📋
<!--
Example how to mark a checkbox :-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots (if required) 📷

![image](https://user-images.githubusercontent.com/67039214/112727592-320c8d00-8f49-11eb-97ef-8fb79e74afab.png)



