### PR TITLE
Added Delete button change of Color

### DIFF
--- a/app/src/main/res/layout/fragment_profile.xml
+++ b/app/src/main/res/layout/fragment_profile.xml
@@ -37,7 +37,7 @@
             android:layout_marginStart="@dimen/largeMargin"
             android:layout_marginTop="@dimen/mediumMargin"
             android:background="@drawable/rounded_buttons"
-            android:backgroundTint="@color/darkIconTint"
+            android:backgroundTint="@color/errorTint"
             android:text="@string/profile_screen_delete_account"
             android:textColor="@color/alternativeText"
             android:textSize="@dimen/mediumText"


### PR DESCRIPTION
## Description:
Currently, the delete button on the profile section uses a Black color as background. If it was replaced with Red, it would improve the user interface.

## Screenshot of Current profile screen:
![WhatsApp Image 2021-05-28 at 8 08 20 AM](https://user-images.githubusercontent.com/54114888/119922981-86a2a780-bf8e-11eb-9792-de83335b1994.jpeg)

## Screenshot of Improved profile screen:
![WhatsApp Image 2021-05-28 at 8 22 23 AM](https://user-images.githubusercontent.com/54114888/119923029-991ce100-bf8e-11eb-96e7-05378771512f.jpeg)
